### PR TITLE
Fix quoting in the Dockerfile so variables are expanded too early

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ USER root
 RUN fix-permissions "/home/${NB_USER}/.ipython"
 RUN fix-permissions "/home/${NB_USER}/.cache"
 
-RUN echo "PS1='\[\033[01;32m\]${JUPYTERHUB_USER}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\] >>> '" >> /etc/bash.bashrc
+RUN echo 'PS1="\[\033[01;32m\]${JUPYTERHUB_USER}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\] >>> "' >> /etc/bash.bashrc
 RUN echo 'cd ${HOME}' >> /etc/bash.bashrc
 
 USER ${NB_UID}


### PR DESCRIPTION
If the outer quotes are `"` then the `JUPYTERHUB_USER` variable is expanded at build time, not at run time