### PR TITLE
fix permissions for docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,7 @@ jobs:
       packages: write
       contents: read
       attestations: write
+      id-token: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
This added permission is required so that the "Generate artifact attestation" build step has permission to generate the correct id token (see: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings)